### PR TITLE
r/site: support "account_slug" to create site in team

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,17 @@ test-compile:
 	go test -c $(TEST) $(TESTARGS)
 
 website:
-	ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-		echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-		git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-	endif
-		@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 website-test:
-	ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-		echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-		git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-	endif
-		@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
+	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
+	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
+endif
+	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test

--- a/netlify/resource_site.go
+++ b/netlify/resource_site.go
@@ -33,6 +33,17 @@ func resourceSite() *schema.Resource {
 				Computed: true,
 			},
 
+			"account_slug": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"account_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"repo": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -78,15 +89,33 @@ func resourceSite() *schema.Resource {
 func resourceSiteCreate(d *schema.ResourceData, metaRaw interface{}) error {
 	meta := metaRaw.(*Meta)
 
-	params := operations.NewCreateSiteParams()
-	params.Site = resourceSite_setupStruct(d)
+	// If we have an "account_slug" set we use a different API path that lets
+	// us create a site in a specific team. Unfortunately we have to duplicate
+	// a lot of stuff because the types are totally different even though
+	// structurally they are identical.
+	var site *models.Site
+	if v, ok := d.GetOk("account_slug"); ok {
+		params := operations.NewCreateSiteInTeamParams()
+		params.AccountSlug = v.(string)
+		params.Site = resourceSite_setupStruct(d)
+		resp, err := meta.Netlify.Operations.CreateSiteInTeam(params, meta.AuthInfo)
+		if err != nil {
+			return err
+		}
 
-	resp, err := meta.Netlify.Operations.CreateSite(params, meta.AuthInfo)
-	if err != nil {
-		return err
+		site = resp.Payload
+	} else {
+		params := operations.NewCreateSiteParams()
+		params.Site = resourceSite_setupStruct(d)
+		resp, err := meta.Netlify.Operations.CreateSite(params, meta.AuthInfo)
+		if err != nil {
+			return err
+		}
+
+		site = resp.Payload
 	}
 
-	d.SetId(resp.Payload.ID)
+	d.SetId(site.ID)
 	return resourceSiteRead(d, metaRaw)
 }
 
@@ -109,6 +138,8 @@ func resourceSiteRead(d *schema.ResourceData, metaRaw interface{}) error {
 	d.Set("name", site.Name)
 	d.Set("custom_domain", site.CustomDomain)
 	d.Set("deploy_url", site.DeployURL)
+	d.Set("account_slug", site.AccountSlug)
+	d.Set("account_name", site.AccountName)
 	d.Set("repo", nil)
 
 	if site.BuildSettings != nil {


### PR DESCRIPTION
This adds support to create a site within a specific "team" in Netlify.

We need this particularly at HashiCorp since we want to use the provider to create the site directly into our "hashicorp" team.

**Why aren't there any tests?!!** To test this, you'd need to either have a team already or create a team dynamically. We can't do the latter (create dynamically) because there is no free tier for teams, so you need to setup payments and all that all via the API which is nasty and would also require us to know CC details somehow. We can't reliably do the former since that requires our test account to have a team setup. I could add a test with an env var check here but I thought maybe because the code paths are so similar it might be okay?

I built and tested the resource manually and it worked.