### PR TITLE
resource_site.go: only set repo attribute on read if there is a repo path

### DIFF
--- a/netlify/resource_site.go
+++ b/netlify/resource_site.go
@@ -111,7 +111,7 @@ func resourceSiteRead(d *schema.ResourceData, metaRaw interface{}) error {
 	d.Set("deploy_url", site.DeployURL)
 	d.Set("repo", nil)
 
-	if site.BuildSettings != nil {
+	if site.BuildSettings != nil && site.BuildSettings.RepoPath != "" {
 		d.Set("repo", []interface{}{
 			map[string]interface{}{
 				"command":       site.BuildSettings.Cmd,


### PR DESCRIPTION
Fixes some failing acceptance tests.
Needs #20 and #2 to fix prior acceptance test bug.

### Fix

If a site resource does not have a repo defined, the Netlify API will still return BuildSettings in the read response payload.

Now we check for the RepoPath in the response. If this is not empty, it means the resource must have a repo defined, as it is a required attribute.

Fixes bug where a perpetual non-empty plan would be produced for sites without a repo defined.

### Acceptance tests before
```
$ make testacc TESTARGS="-run=TestAccBuildHook"
==> Checking that code complies with gofmt requirements...
TF_ACC_IDONLY=1 TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccBuildHook -timeout 120m
?   	github.com/terraform-providers/terraform-provider-netlify	[no test files]
=== RUN   TestAccBuildHook
--- FAIL: TestAccBuildHook (2.13s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: netlify_site.test
          repo.#: "1" => "0"
        
        STATE:
        
        netlify_build_hook.test:
          ID = 5cdeb6066f7f41f6472781a1
          provider = provider.netlify
          branch = master
          site_id = b8044476-a99e-4e08-abaf-dd093f551aae
          title = tubes
          url = https://api.netlify.com/build_hooks/5cdeb6066f7f41f6472781a1
        
          Dependencies:
            netlify_site.test
        netlify_site.test:
          ID = b8044476-a99e-4e08-abaf-dd093f551aae
          provider = provider.netlify
          custom_domain = 
          deploy_url = http://.quirky-wescoff-a78268.netlify.com
          name = quirky-wescoff-a78268
          repo.# = 1
          repo.0.command = 
          repo.0.deploy_key_id = 
          repo.0.dir = 
          repo.0.provider = 
          repo.0.repo_branch = 
          repo.0.repo_path =
=== RUN   TestAccBuildHook_disappears
--- PASS: TestAccBuildHook_disappears (1.91s)
=== RUN   TestAccBuildHook_updateBranch
--- FAIL: TestAccBuildHook_updateBranch (1.81s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: netlify_site.test
          repo.#: "1" => "0"
        
        STATE:
        
        netlify_build_hook.test:
          ID = 5cdeb60ab6ae06747601816e
          provider = provider.netlify
          branch = master
          site_id = b6919046-ed3e-4e0d-8574-ae07ae161f3e
          title = tubes
          url = https://api.netlify.com/build_hooks/5cdeb60ab6ae06747601816e
        
          Dependencies:
            netlify_site.test
        netlify_site.test:
          ID = b6919046-ed3e-4e0d-8574-ae07ae161f3e
          provider = provider.netlify
          custom_domain = 
          deploy_url = http://.musing-booth-3f3e23.netlify.com
          name = musing-booth-3f3e23
          repo.# = 1
          repo.0.command = 
          repo.0.deploy_key_id = 
          repo.0.dir = 
          repo.0.provider = 
          repo.0.repo_branch = 
          repo.0.repo_path =
FAIL
FAIL	github.com/terraform-providers/terraform-provider-netlify/netlify	5.882s
make: *** [Makefile:18: testacc] Error 1
```


### Acceptance tests after
```
$ make testacc TESTARGS="-run=TestAccBuildHook"
==> Checking that code complies with gofmt requirements...
TF_ACC_IDONLY=1 TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccBuildHook -timeout 120m
?   	github.com/terraform-providers/terraform-provider-netlify	[no test files]
=== RUN   TestAccBuildHook
--- PASS: TestAccBuildHook (2.52s)
=== RUN   TestAccBuildHook_disappears
--- PASS: TestAccBuildHook_disappears (2.27s)
=== RUN   TestAccBuildHook_updateBranch
--- PASS: TestAccBuildHook_updateBranch (3.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-netlify/netlify	8.145s
```