### PR TITLE
Makefile: do not require $GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ website/node_modules
 *.iml
 *.test
 *.iml
+website-repo

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-WEBSITE_REPO=github.com/hashicorp/terraform-website
+WEBSITE_REPO=hashicorp/terraform-website
 PKG_NAME=netlify
-
 
 default: build
 
@@ -46,18 +45,16 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-website:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+website-repo: clean
+	git clone https://github.com/$(WEBSITE_REPO) website-repo
 
-website-test:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+website: website-repo
+	$(MAKE) -C website-repo website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+website-test: website-repo
+	$(MAKE) -C website-repo website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
+
+clean:
+	rm -rf website-repo
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test clean


### PR DESCRIPTION
As of Go 1.11, we can no longer assume that environments with Go installed have $GOPATH set. Without this set, the Makefile would attempt to clone the website repo into /src, which will fail in most environments.

The website targets would also not update the local copy of the website repo to the latest version.

We now retrieve a fresh clone of the website repo whenever it is needed.